### PR TITLE
Best effort for detecting found testbin content type

### DIFF
--- a/testbin/testbin.go
+++ b/testbin/testbin.go
@@ -9,6 +9,8 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -18,6 +20,7 @@ import (
 	"emperror.dev/errors"
 
 	"github.com/kralicky/spellbook/internal/deps"
+	"github.com/magefile/mage/sh"
 	"github.com/mholt/archiver/v4"
 )
 
@@ -28,6 +31,11 @@ var (
 	SerialDeps    = testbinDeps.SerialDeps
 	CtxDeps       = testbinDeps.CtxDeps
 	SerialCtxDeps = testbinDeps.SerialCtxDeps
+)
+
+const (
+	testBinTypeCompressed = "compressed"
+	testBinTypeExecutable = "executable"
 )
 
 type GetVersionFunc func(bin string) string
@@ -49,23 +57,22 @@ var Config = struct {
 	Dir: "testbin/bin",
 }
 
-func fallbackUntar(binaryName, dst string, r io.Reader) error {
+func fallbackUntar(binaryName, dst string, r io.Reader) (fs.File, error) {
 	gzr, err := gzip.NewReader(r)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer gzr.Close()
 
 	tr := tar.NewReader(gzr)
-
 	for {
 		header, err := tr.Next()
 
 		switch {
 		case err == io.EOF:
-			return nil
+			return nil, err
 		case err != nil:
-			return err
+			return nil, err
 		case header == nil:
 			continue
 		}
@@ -78,18 +85,22 @@ func fallbackUntar(binaryName, dst string, r io.Reader) error {
 		case tar.TypeDir:
 			// ignore
 		case tar.TypeReg:
-			f, err := os.OpenFile(target, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
-			if err != nil {
-				return err
-			}
-			// copy over contents
-			if _, err := io.Copy(f, tr); err != nil {
-				return err
+			if strings.HasSuffix(header.Name, binaryName) {
+				f, err := os.OpenFile(target+"-extracted", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+				if err != nil {
+					return nil, err
+				}
+				// copy over contents
+				if _, err := io.Copy(f, tr); err != nil {
+					return nil, err
+				}
+				//seek to the beginning of the file, because it is copied later
+				if _, err := f.Seek(0, io.SeekStart); err != nil {
+					return nil, err
+				}
+				return f, nil
 			}
 
-			// manually close here after each file operation; defering would cause each file close
-			// to wait until all operations have completed.
-			f.Close()
 		}
 	}
 }
@@ -149,6 +160,93 @@ type binaryTemplateData struct {
 	GOARCH  string
 }
 
+func getFileType(filepath string) (string, error) {
+	// we default to the more common case of treating release binaries as compressed
+	unkownType := testBinTypeCompressed
+
+	buf := make([]byte, 512) // max length required for sniff algorithm of net/http
+	f, err := os.Open(filepath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	_, err = f.Read(buf)
+	if err != nil {
+		return "", err
+	}
+	// the api we get the test binary from can sometimes encode hints about the content type
+	encodedFiletype := http.DetectContentType(buf)
+	switch encodedFiletype {
+	case "application/x-gzip", "application/gzip", "application/zip":
+		return testBinTypeCompressed, nil
+	case "application/octet-stream":
+		// apis like github /download frequently return this type despite having compressed contents
+		fallthrough
+	default:
+		// no-op
+	}
+
+	// the api didn't have enough information to evaluate file type, fallback
+	// to gnu/gpl file utility
+
+	_, err = exec.LookPath("file")
+	if err != nil {
+		// this will always fail for windows users that have not manually installed gnu file
+		// so this is treated as a recoverable error
+		return unkownType, nil
+	}
+
+	discoveredProperties, err := sh.Output("file", filepath)
+	if err != nil {
+		return unkownType, nil
+	}
+
+	if strings.Contains("executable", discoveredProperties) {
+		return testBinTypeExecutable, nil
+	}
+	if strings.Contains("compressed", discoveredProperties) {
+		return testBinTypeCompressed, nil
+	}
+	return unkownType, nil
+}
+
+func extract(fsys fs.FS, binary Binary, archiveFile string) (fs.File, error) {
+	if bin, err := fsys.Open(binary.Name); err == nil {
+		return bin, err
+	} else if bin, err := fsys.Open(filepath.Base(archiveFile)); err == nil {
+		return bin, nil
+	} else if bin, err := fsys.Open(binary.PathInArchive); binary.PathInArchive != "" && err == nil {
+		return bin, err
+	} else {
+		var topLevelDir string
+		entries, err := fs.ReadDir(fsys, ".")
+		if err != nil {
+			return nil, err
+		}
+		if len(entries) == 0 { // something is wrong, try fallback
+			archiveReader, err := os.Open(archiveFile)
+			if err != nil {
+				return nil, err
+			}
+			defer archiveReader.Close()
+			return fallbackUntar(binary.Name, path.Dir(archiveFile), archiveReader)
+		} else if len(entries) == 1 {
+			topLevelDir = entries[0].Name()
+		} else {
+			return nil, errors.New(fmt.Sprintf("unexpected number of top-level directories in archive (%d)", len(entries)))
+		}
+		if bin, err := fsys.Open(filepath.Join(topLevelDir, binary.Name)); err == nil {
+			return bin, nil
+		} else if bin, err := fsys.Open(filepath.Join(topLevelDir, "bin", binary.Name)); err == nil {
+			return bin, nil
+		} else if bin, err := fsys.Open(filepath.Join(topLevelDir, binary.PathInArchive)); binary.PathInArchive != "" && err == nil {
+			return bin, nil
+		} else {
+			return nil, errors.New("could not auto-detect binary in archive")
+		}
+	}
+}
+
 func downloadBinary(binary Binary) error {
 	fmt.Printf("downloading %s version %s...\n", binary.Name, binary.Version)
 	tempDir, err := os.MkdirTemp("", "testbin-download-*")
@@ -177,6 +275,7 @@ func downloadBinary(binary Binary) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
+
 	archiveFile := filepath.Join(tempDir, binary.Name+"-archive")
 	f, err := os.Create(archiveFile)
 	if err != nil {
@@ -186,48 +285,33 @@ func downloadBinary(binary Binary) error {
 		return err
 	}
 	f.Close()
-
 	fsys, err := archiver.FileSystem(archiveFile)
 	if err != nil {
 		return err
 	}
 
+	filetype, err := getFileType(archiveFile)
+	if err != nil {
+		return err
+	}
+	// assumption here is the fs.File is opened but not closed
 	var fsFile fs.File
-	if bin, err := fsys.Open(binary.Name); err == nil {
-		fsFile = bin
-	} else if bin, err := fsys.Open(filepath.Base(archiveFile)); err == nil {
-		fsFile = bin
-	} else if bin, err := fsys.Open(binary.PathInArchive); binary.PathInArchive != "" && err == nil {
-		fsFile = bin
-	} else {
-		var topLevelDir string
-		entries, err := fs.ReadDir(fsys, ".")
-		if err != nil {
-			return err
+	defer func() {
+		if fsFile != nil {
+			fsFile.Close()
 		}
-		if len(entries) == 0 { // something is wrong, try fallback
-			archiveReader, err := os.Open(archiveFile)
-			if err != nil {
-				archiveReader.Close()
-				return err
-			}
-			fallbackUntar(binary.Name, Config.Dir, archiveReader)
-			archiveReader.Close()
-			return nil
-		} else if len(entries) == 1 {
-			topLevelDir = entries[0].Name()
-		} else {
-			return errors.New(fmt.Sprintf("unexpected number of top-level directories in archive (%d)", len(entries)))
-		}
-		if bin, err := fsys.Open(filepath.Join(topLevelDir, binary.Name)); err == nil {
-			fsFile = bin
-		} else if bin, err := fsys.Open(filepath.Join(topLevelDir, "bin", binary.Name)); err == nil {
-			fsFile = bin
-		} else if bin, err := fsys.Open(filepath.Join(topLevelDir, binary.PathInArchive)); binary.PathInArchive != "" && err == nil {
-			fsFile = bin
-		} else {
-			return errors.New("could not auto-detect binary in archive")
-		}
+	}()
+	var fTypeErr error
+	switch filetype {
+	case testBinTypeCompressed:
+		fsFile, fTypeErr = extract(fsys, binary, archiveFile)
+	case testBinTypeExecutable:
+		fsFile, fTypeErr = f, nil
+	default:
+		fTypeErr = fmt.Errorf("unknown detected file type, cannot be handled by testbin target: %s", filetype)
+	}
+	if fTypeErr != nil {
+		return fTypeErr
 	}
 
 	bin, err := os.OpenFile(filepath.Join(Config.Dir, binary.Name), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)


### PR DESCRIPTION
Motivation :

Release binaries are usually distributed through compressed form (gzip+tar) however not all binary providers will do so.

For example trying to integrate `testbin` targets with some useful TLS binaries from [cloudflare's cfssl](https://github.com/cloudflare/cfssl) fails because they distribute them without compression.

Proposal: 
- sniff the http response body for hints at the content type the binary may contain; note the fallback is `application/octet-stream`; github's `/download` api frequently gets sniffed as an octet stream (even if contents are compressed) so we need some additional checks.

- if the source api itself doesn't contain any hints, use GNU `file` utility.

- windows users do not have access to the `file` utility through their OS, so if file is not found in the `PATH`, fallback to the original behavior of treating all testbin binaries as compressed through gzip